### PR TITLE
Adding macOS support

### DIFF
--- a/uvclite/libuvc.py
+++ b/uvclite/libuvc.py
@@ -58,9 +58,8 @@ __all__ = [
     'uvc_print_diag'
 ]
 
-# TODO: create function for more robust library loading, that should hopefully
-# work on all platforms
-_libuvc = CDLL('libuvc.so')
+# Load the correct version of the lib on macOS
+_libuvc = CDLL('libuvc.dylib' if platform.system() == "Darwin" else 'libuvc.so')
 
 def buffer_at(address, length):
     """

--- a/uvclite/libuvc.py
+++ b/uvclite/libuvc.py
@@ -20,6 +20,7 @@
 from ctypes import *
 import errno
 from enum import Enum
+import platform
 
 __author__ = 'Eric Callahan'
 


### PR DESCRIPTION
On macOS, the correct library for libuvc is found as "libuvc.dylib" instead of "libuvc.so". I have added a check to the loading code so it loads the correct library depending on if it is running on a macOS system or a Linux system. (I tested this on my Mac and it works as intended.) 